### PR TITLE
web-term 3.1.0

### DIFF
--- a/.blah/README.ejs
+++ b/.blah/README.ejs
@@ -67,21 +67,30 @@ Then, run `<%- _.pack.name %> --help` and see what the cli tool can do.
 Run `web-term` and then open `localhost:9000` in your web browser. If you want to configure the things, run `web-term -h`
 and see what are the available options.
 
-In short:
-
- - `-d` Starts `web-term` as daemon (e.g. `web-term -d`)
- - `-p <port>` Sets a different port (e.g. `web-term -p 5000`)
- - `-o` Opens the `web-term` page in the default browser.
- - `-c <cwd>` Specifies the current working directory.
-
-Sure, they can be combined:
-
 ```sh
-# The following command will start web-term as daemon
-# on localhost:5000, with the current working directory
-# set to ~/Documents and after the process is started,
-# the web-term page will be opened in browser.
-$ web-term -d -p 5000 -c ~/Documents -o
+$ ./bin/web-term -h
+Usage: web-term [options]
+
+Options:
+  -p, --port <port>      The web term server port.
+  -d, --daemon           Start web term as background process.
+  -c, --cwd <path>       The path to the web terminal current working
+                         directory.
+  -o, --open             If provided, the web term will be automatically
+                         opened in the default browser.
+  -s, --start <program>  The start program. By default the current shell.
+  -h, --help             Displays this help.
+  -v, --version          Displays version information.
+
+Examples:
+  web-term # Default behavior
+  web-term -p 8080 # start on localhost:8080
+  web-term -d # daemonize
+  web-term -c path/to/some/dir
+  web-term -o # Opens the web-term in the browser
+  web-term -s alsamixer # Opens alsamixer in the browser
+
+Documentation can be found at https://github.com/IonicaBizau/web-term
 ```
 
 ## Screenshots

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7,12 +7,15 @@ Creates a new `WebTerm` instance.
 #### Return
 - **WebTerm** The `WebTerm` instance.
 
-### `create(options, callback)`
+### `create(options)`
 Creates a new terminal instance.
 
 #### Params
-- **Object** `options`: Creates a new terminal instance.
-- **Function** `callback`: The callback function.
+- **Object** `options`: Creates a new terminal instance:
+ - `cols` (Number): The number of columns.
+ - `rows` (Number): The number of rows.
+ - `cwd` (String): The current working directory (default: the home directory).
+ - `start` (String): The start program (by default the shell).
 
 #### Return
 - **Terminal** The terminal instance.

--- a/README.md
+++ b/README.md
@@ -38,21 +38,30 @@ Then, run `web-term --help` and see what the cli tool can do.
 Run `web-term` and then open `localhost:9000` in your web browser. If you want to configure the things, run `web-term -h`
 and see what are the available options.
 
-In short:
-
- - `-d` Starts `web-term` as daemon (e.g. `web-term -d`)
- - `-p <port>` Sets a different port (e.g. `web-term -p 5000`)
- - `-o` Opens the `web-term` page in the default browser.
- - `-c <cwd>` Specifies the current working directory.
-
-Sure, they can be combined:
-
 ```sh
-# The following command will start web-term as daemon
-# on localhost:5000, with the current working directory
-# set to ~/Documents and after the process is started,
-# the web-term page will be opened in browser.
-$ web-term -d -p 5000 -c ~/Documents -o
+$ ./bin/web-term -h
+Usage: web-term [options]
+
+Options:
+  -p, --port <port>      The web term server port.
+  -d, --daemon           Start web term as background process.
+  -c, --cwd <path>       The path to the web terminal current working
+                         directory.
+  -o, --open             If provided, the web term will be automatically
+                         opened in the default browser.
+  -s, --start <program>  The start program. By default the current shell.
+  -h, --help             Displays this help.
+  -v, --version          Displays version information.
+
+Examples:
+  web-term # Default behavior
+  web-term -p 8080 # start on localhost:8080
+  web-term -d # daemonize
+  web-term -c path/to/some/dir
+  web-term -o # Opens the web-term in the browser
+  web-term -s alsamixer # Opens alsamixer in the browser
+
+Documentation can be found at https://github.com/IonicaBizau/web-term
 ```
 
 ## Screenshots

--- a/bin/public/horizontal-split.html
+++ b/bin/public/horizontal-split.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=utf-8">
+        <title>Vertical split</title>
+        <link rel="icon" type="image/png" href="img/favicon.png" />
+        <style>
+            iframe {
+                position: fixed;
+                left: 0;
+                right: 0;
+                border: none;
+                width: 100%;
+                height: 50%;
+            }
+            iframe.top { top: 0; }
+            iframe.bottom { bottom: 0; }
+        </style>
+    </head>
+    <body>
+        <iframe class="top" src="index.html"></iframe>
+        <iframe class="bottom" src="index.html"></iframe>
+    </body>
+</html>

--- a/bin/public/js/web-term.js
+++ b/bin/public/js/web-term.js
@@ -1,7 +1,7 @@
 (function ($) {
     var EventEmitter = Terminal.EventEmitter;
 
-    blm("Do you really want to leave? You will lose this terminal session.");
+    //blm("Do you really want to leave? You will lose this terminal session.");
 
     // Text size plugin
     $.fn.textSize = function () {
@@ -137,5 +137,6 @@
 })($);
 
 $(document).ready(function() {
-    $(".container").webTerm();
+    $(".container-term").webTerm();
+    $(".container-term2").webTerm.create();
 });

--- a/bin/public/js/web-term.js
+++ b/bin/public/js/web-term.js
@@ -1,7 +1,7 @@
 (function ($) {
     var EventEmitter = Terminal.EventEmitter;
 
-    //blm("Do you really want to leave? You will lose this terminal session.");
+    blm("Do you really want to leave? You will lose this terminal session.");
 
     // Text size plugin
     $.fn.textSize = function () {
@@ -137,7 +137,5 @@
 })($);
 
 $(document).ready(function() {
-    $(".container-term").webTerm();
-    $(".container-term2").webTerm.create();
-    //  $(".container-term2").terminal.create();
+    $(".container").webTerm();
 });

--- a/bin/public/js/web-term.js
+++ b/bin/public/js/web-term.js
@@ -139,4 +139,5 @@
 $(document).ready(function() {
     $(".container-term").webTerm();
     $(".container-term2").webTerm.create();
+    //  $(".container-term2").terminal.create();
 });

--- a/bin/public/js/web-term.js
+++ b/bin/public/js/web-term.js
@@ -96,7 +96,6 @@
             // Create the terminal
             term.socket.emit("create", win.cols, win.rows, function(err, data) {
                 if (err) return self._destroy();
-                $title.text(data.process);
                 term.emit("open tab", term);
                 term.emit("open");
                 term.updateSize();

--- a/bin/public/vertical-split.html
+++ b/bin/public/vertical-split.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=utf-8">
+        <title>Vertical split</title>
+        <link rel="icon" type="image/png" href="img/favicon.png" />
+        <style>
+            iframe {
+                position: fixed;
+                top: 0;
+                bottom: 0;
+                border: none;
+                width: 50%;
+                height: 100%;
+            }
+            iframe.left { left: 0; }
+            iframe.right { right: 0; }
+        </style>
+    </head>
+    <body>
+        <iframe class="left" src="index.html"></iframe>
+        <iframe class="right" src="index.html"></iframe>
+    </body>
+</html>

--- a/bin/web-term
+++ b/bin/web-term
@@ -19,6 +19,7 @@ var portOption = new Clp.Option(["p", "port"], "The web term server port.", "por
   , daemonOption = new Clp.Option(["d", "daemon"], "Start web term as background process.")
   , cwdOption = new Clp.Option(["c", "cwd"], "The path to the web terminal current working directory.", "path")
   , openOption = new Clp.Option(["o", "open"], "If provided, the web term will be automatically opened in the default browser.")
+  , startOption = new Clp.Option(["s", "start"], "The start program. By default the current shell.", "program", "bash")
   , parser = new Clp({
         name: "Web Term"
       , version: Package.version
@@ -32,7 +33,7 @@ var portOption = new Clp.Option(["p", "port"], "The web term server port.", "por
           , "web-term -o # Opens the web-term in browser"
         ]
       , docs_url: "https://github.com/IonicaBizau/web-term"
-    }, [portOption, daemonOption, cwdOption, openOption])
+    }, [portOption, daemonOption, cwdOption, openOption, startOption])
   ;
 
 
@@ -87,11 +88,13 @@ app.io.sockets.on("connection", function(socket) {
 
     socket.on("create", function(cols, rows, callback) {
         terminal = new WebTerm({
-          cols: cols
-        , rows: rows
-        , cwd: cwdOption.value || process.cwd()
-        , socket: socket
-      }, callback);
+            cols: cols
+          , rows: rows
+          , cwd: cwdOption.value || process.cwd()
+          , socket: socket
+          , start: startOption.value
+        });
+        callback();
     });
 
     socket.on("data", function(data) {

--- a/bin/web-term
+++ b/bin/web-term
@@ -82,48 +82,42 @@ app.io.sockets.on("connection", function(socket) {
     var req = socket.handshake;
     var user = req.user;
 
+    // One terminal per web-socket
     var terminal = null;
 
     socket.on("create", function(cols, rows, callback) {
         terminal = new WebTerm({
           cols: cols
         , rows: rows
-        , socket: socket
         , cwd: cwdOption.value || process.cwd()
+        , socket: socket
       }, callback);
     });
-        /*WebTerm.create({
-            cols: cols
-          , rows: rows
-          , socket: socket
-          , cwd: cwdOption.value || process.cwd()
-        }, callback);
-
-    });*/
 
     socket.on("data", function(data) {
-        WebTerm.data(data);
-        //terminal.data(data);
+        if (!terminal) { return; }
+        terminal.data(data);
     });
 
     socket.on("kill", function() {
-        WebTerm.kill();
-        //terminal.kill();
+        if (!terminal) { return; }
+        terminal.kill();
     });
 
     socket.on("resize", function(cols, rows) {
-        WebTerm.resize(cols, rows);
-        //terminal.resize(cols, rows);
+        if (!terminal) { return; }
+        terminal.resize(cols, rows);
     });
 
     socket.on("disconnect", function() {
-        WebTerm.kill();
-        //terminal.kill();
+        if (!terminal) { return; }
+        terminal.kill();
+        terminal = null;
     });
 
     socket.on("request paste", function(callback) {
-        WebTerm.paste(callback);
-        //terminal.paste(callback);
+        if (!terminal) { return; }
+        terminal.paste(callback);
     });
 });
 

--- a/bin/web-term
+++ b/bin/web-term
@@ -69,9 +69,9 @@ var app = new Lien({
 });
 
 // Add the route
-app.page.add("/", function (lien) {
-    lien.file("index.html");
-});
+app.page.add("/", "index.html");
+app.page.add("/vs", "vertical-split.html");
+app.page.add("/hs", "horizontal-split.html");
 
 // Init Socket.IO
 app.io = SocketIO.listen(app._server, {

--- a/bin/web-term
+++ b/bin/web-term
@@ -102,28 +102,28 @@ app.io.sockets.on("connection", function(socket) {
     });*/
 
     socket.on("data", function(data) {
-        //WebTerm.data(data);
-        terminal.data(data);
+        WebTerm.data(data);
+        //terminal.data(data);
     });
 
     socket.on("kill", function() {
-        //WebTerm.kill();
-        terminal.kill();
+        WebTerm.kill();
+        //terminal.kill();
     });
 
     socket.on("resize", function(cols, rows) {
-        //WebTerm.resize(cols, rows);
-        terminal.resize(cols, rows);
+        WebTerm.resize(cols, rows);
+        //terminal.resize(cols, rows);
     });
 
     socket.on("disconnect", function() {
-        //WebTerm.kill();
-        terminal.kill();
+        WebTerm.kill();
+        //terminal.kill();
     });
 
     socket.on("request paste", function(callback) {
-        //WebTerm.paste(callback);
-        terminal.paste(callback);
+        WebTerm.paste(callback);
+        //terminal.paste(callback);
     });
 });
 

--- a/bin/web-term
+++ b/bin/web-term
@@ -82,33 +82,48 @@ app.io.sockets.on("connection", function(socket) {
     var req = socket.handshake;
     var user = req.user;
 
+    var terminal = null;
+
     socket.on("create", function(cols, rows, callback) {
-        WebTerm.create({
+        terminal = new WebTerm({
+          cols: cols
+        , rows: rows
+        , socket: socket
+        , cwd: cwdOption.value || process.cwd()
+      }, callback);
+    });
+        /*WebTerm.create({
             cols: cols
           , rows: rows
           , socket: socket
           , cwd: cwdOption.value || process.cwd()
         }, callback);
-    });
+
+    });*/
 
     socket.on("data", function(data) {
-        WebTerm.data(data);
+        //WebTerm.data(data);
+        terminal.data(data);
     });
 
     socket.on("kill", function() {
-        WebTerm.kill();
+        //WebTerm.kill();
+        terminal.kill();
     });
 
     socket.on("resize", function(cols, rows) {
-        WebTerm.resize(cols, rows);
+        //WebTerm.resize(cols, rows);
+        terminal.resize(cols, rows);
     });
 
     socket.on("disconnect", function() {
-        WebTerm.kill();
+        //WebTerm.kill();
+        terminal.kill();
     });
 
     socket.on("request paste", function(callback) {
-        WebTerm.paste(callback);
+        //WebTerm.paste(callback);
+        terminal.paste(callback);
     });
 });
 

--- a/bin/web-term
+++ b/bin/web-term
@@ -30,7 +30,8 @@ var portOption = new Clp.Option(["p", "port"], "The web term server port.", "por
           , "web-term -p 8080 # start on localhost:8080"
           , "web-term -d # daemonize"
           , "web-term -c path/to/some/dir"
-          , "web-term -o # Opens the web-term in browser"
+          , "web-term -o # Opens the web-term in the browser"
+          , "web-term -s alsamixer # Opens alsamixer in the browser"
         ]
       , docs_url: "https://github.com/IonicaBizau/web-term"
     }, [portOption, daemonOption, cwdOption, openOption, startOption])

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,4 +106,4 @@ WebTerm.prototype.resize = function (cols, rows) {
     this.terminal.resize(cols, rows);
 };
 
-//module.exports = new WebTerm();
+module.exports = WebTerm();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 // Dependencies
-var Pty = require("pty.js");
+var Pty = require("pty.js")
+  , Ul = require("ul")
+  ;
 
 /**
  * WebTerm
@@ -10,7 +12,7 @@ var Pty = require("pty.js");
  * @return {WebTerm} The `WebTerm` instance.
  */
 function WebTerm() {
-    //this.terminal = null;
+    this.terminal = null;
     this.create(options);
 }
 
@@ -20,38 +22,21 @@ function WebTerm() {
  *
  * @name create
  * @function
- * @param {Object} options Creates a new terminal instance.
- * @param {Function} callback The callback function.
+ * @param {Object} options Creates a new terminal instance:
+ *
+ *  - `cols` (Number): The number of columns.
+ *  - `rows` (Number): The number of rows.
+ *  - `cwd` (String): The current working directory (default: the home directory).
+ *
  * @return {Terminal} The terminal instance.
  */
 WebTerm.prototype.create = function (options, callback) {
 
     var self = this;
     self.terminal = Pty.fork(process.env.SHELL, [], {
-        cols: options.cols,
-        rows: options.rows,
-        cwd: options.cwd || process.env.HOME
-    });
-
-    self.terminal.on("data", function(data) {
-        options.socket.emit("data", data);
-    });
-
-    self.terminal.on("close", function() {
-        options.socket.emit("kill");
-        self.kill();
-    });
-
-    return self.terminal;
-};
-
-WebTerm.prototype.create = function (options, callback) {
-
-    var self = this;
-    self.terminal = Pty.fork(process.env.SHELL, [], {
-        cols: options.cols,
-        rows: options.rows,
-        cwd: options.cwd || process.env.HOME
+        cols: options.cols
+      , rows: options.rows
+      , cwd: options.cwd || Ul.home()
     });
 
     self.terminal.on("data", function(data) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 // Dependencies
 var Pty = require("pty.js")
   , Ul = require("ul")
+  , Deffy = require("deffy")
   ;
 
 /**
@@ -27,13 +28,15 @@ function WebTerm (options) {
  *  - `cols` (Number): The number of columns.
  *  - `rows` (Number): The number of rows.
  *  - `cwd` (String): The current working directory (default: the home directory).
+ *  - `start` (String): The start program (by default the shell).
  *
  * @return {Terminal} The terminal instance.
  */
 WebTerm.prototype.create = function (options, callback) {
 
     var self = this;
-    self.terminal = Pty.fork(process.env.SHELL, [], {
+    options.start = Deffy(options.start, process.env.SHELL);
+    self.terminal = Pty.fork(options.start, [], {
         cols: options.cols
       , rows: options.rows
       , cwd: options.cwd || Ul.home()

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,10 +11,7 @@ var Pty = require("pty.js");
  */
 function WebTerm() {
     this.terminal = null;
-}
-
-function WebTerm2() {
-    this.terminal = null;
+    this.create(options);
 }
 
 /**
@@ -48,7 +45,7 @@ WebTerm.prototype.create = function (options, callback) {
     return self.terminal;
 };
 
-WebTerm2.prototype.create = function (options, callback) {
+WebTerm.prototype.create = function (options, callback) {
 
     var self = this;
     self.terminal = Pty.fork(process.env.SHELL, [], {
@@ -82,11 +79,6 @@ WebTerm.prototype.data = function (data) {
     this.terminal.write(data);
 };
 
-WebTerm2.prototype.data = function (data) {
-    if (!this.terminal) { return; }
-    this.terminal.write(data);
-};
-
 /**
  * kill
  * Destroys the `WebTerm` instance.
@@ -95,12 +87,6 @@ WebTerm2.prototype.data = function (data) {
  * @function
  */
 WebTerm.prototype.kill = function () {
-    if (!this.terminal) { return; }
-    this.terminal.destroy();
-    this.terminal = null;
-};
-
-WebTerm2.prototype.kill = function () {
     if (!this.terminal) { return; }
     this.terminal.destroy();
     this.terminal = null;
@@ -120,10 +106,4 @@ WebTerm.prototype.resize = function (cols, rows) {
     this.terminal.resize(cols, rows);
 };
 
-WebTerm2.prototype.resize = function (cols, rows) {
-    if (!this.terminal) { return; }
-    this.terminal.resize(cols, rows);
-};
-
-module.exports = new WebTerm();
-module.exports = new WebTerm2();
+//module.exports = new WebTerm();

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,10 @@ function WebTerm() {
     this.terminal = null;
 }
 
+function WebTerm2() {
+    this.terminal = null;
+}
+
 /**
  * create
  * Creates a new terminal instance.
@@ -24,6 +28,27 @@ function WebTerm() {
  * @return {Terminal} The terminal instance.
  */
 WebTerm.prototype.create = function (options, callback) {
+
+    var self = this;
+    self.terminal = Pty.fork(process.env.SHELL, [], {
+        cols: options.cols,
+        rows: options.rows,
+        cwd: options.cwd || process.env.HOME
+    });
+
+    self.terminal.on("data", function(data) {
+        options.socket.emit("data", data);
+    });
+
+    self.terminal.on("close", function() {
+        options.socket.emit("kill");
+        self.kill();
+    });
+
+    return self.terminal;
+};
+
+WebTerm2.prototype.create = function (options, callback) {
 
     var self = this;
     self.terminal = Pty.fork(process.env.SHELL, [], {
@@ -57,6 +82,11 @@ WebTerm.prototype.data = function (data) {
     this.terminal.write(data);
 };
 
+WebTerm2.prototype.data = function (data) {
+    if (!this.terminal) { return; }
+    this.terminal.write(data);
+};
+
 /**
  * kill
  * Destroys the `WebTerm` instance.
@@ -65,6 +95,12 @@ WebTerm.prototype.data = function (data) {
  * @function
  */
 WebTerm.prototype.kill = function () {
+    if (!this.terminal) { return; }
+    this.terminal.destroy();
+    this.terminal = null;
+};
+
+WebTerm2.prototype.kill = function () {
     if (!this.terminal) { return; }
     this.terminal.destroy();
     this.terminal = null;
@@ -84,4 +120,10 @@ WebTerm.prototype.resize = function (cols, rows) {
     this.terminal.resize(cols, rows);
 };
 
+WebTerm2.prototype.resize = function (cols, rows) {
+    if (!this.terminal) { return; }
+    this.terminal.resize(cols, rows);
+};
+
 module.exports = new WebTerm();
+module.exports = new WebTerm2();

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ var Pty = require("pty.js");
  * @return {WebTerm} The `WebTerm` instance.
  */
 function WebTerm() {
-    this.terminal = null;
+    //this.terminal = null;
     this.create(options);
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ var Pty = require("pty.js")
  * @function
  * @return {WebTerm} The `WebTerm` instance.
  */
-function WebTerm() {
+function WebTerm (options) {
     this.terminal = null;
     this.create(options);
 }
@@ -91,4 +91,4 @@ WebTerm.prototype.resize = function (cols, rows) {
     this.terminal.resize(cols, rows);
 };
 
-module.exports = WebTerm();
+module.exports = WebTerm;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-term",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A full screen terminal in your browser.",
   "main": "lib/index.js",
   "bin": {
@@ -29,18 +29,20 @@
     "url": "https://github.com/IonicaBizau/web-term/issues"
   },
   "homepage": "https://github.com/IonicaBizau/web-term",
-  "dependencies": {
-    "bug-killer": "^4.0.0",
-    "clp": "^3.0.0",
-    "diable": "^2.0.0",
-    "is-there": "^4.0.0",
-    "lien": "0.0.12",
-    "opn": "^3.0.2",
-    "pty.js": "^0.2.12",
-    "socket.io": "^1.3.5"
-  },
   "devDependencies": {},
   "blah": {
     "h_img": "http://i.imgur.com/3kMJhvc.png"
+  },
+  "dependencies": {
+    "bug-killer": "^4.0.0",
+    "clp": "^3.0.0",
+    "deffy": "^2.0.0",
+    "diable": "^2.0.0",
+    "lien": "^0.0.12",
+    "is-there": "^4.0.0",
+    "opn": "^3.0.2",
+    "pty.js": "^0.2.13",
+    "socket.io": "^1.3.6",
+    "ul": "^5.0.0"
   }
 }


### PR DESCRIPTION
This release comes with a few new features:
- vertical split (access `http://localhost:9000/vs`)
- horizontal split (access `http://localhost:9000/hs`)
- an options to start a custom program when the terminal is started (e.g. `web-term -s alsamixer`)
- multiple terminal instances for the same server start (but different connections). Fixes #16.
