### PR TITLE
inline-block spans fix for occasional line gap

### DIFF
--- a/bin/public/css/style.css
+++ b/bin/public/css/style.css
@@ -10,6 +10,10 @@ div.terminal > div {
     font-weight: bold;
 }
 
+div.terminal > div > span {
+    display: inline-block;
+}
+
 .terminal {
     font-family: monospace;
     font-size: 11px;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "Ionică Bizău <bizauionica@gmail.com>",
     "Szabo Cristian <lcristianiim@yahoo.com>",
     "Hugues Malphettes <hmalphettes@gmail.com>",
-    "jillix <contact@jillix.com>"
+    "jillix <contact@jillix.com>",
+    "Michael Joseph Rosenthal <rosenthalm93@gmail.com>"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
best solution to gaps between lines in terminal apps with backgrounds is `inline-block <span/>s`.
