### PR TITLE
Support for custom pty options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,34 +4,37 @@
 
 > A full screen terminal in your browser.
 
-## Installation
-
+## :cloud: Installation
+    
 You can install the package globally and use it as command line tool:
 
 ```sh
 $ npm i -g web-term
 ```
+    
 
 Then, run `web-term --help` and see what the CLI tool can do.
 
-```sh
+    
+```
 $ web-term --help
 Usage: web-term [options]
 
 Options:
-  -p, --port <port>      The web term server port.                      
-  -d, --daemon           Start web term as background process.          
-  -c, --cwd <path>       The path to the web terminal current working   
-                         directory.                                     
-  -H, --host <0.0.0.0>   The host to listen to.                         
-  -o, --open             If provided, the web term will be automatically
-                         opened in the default browser.                 
-  -b, --shell <program>  The shell program. By default `bash`.          
-  -s, --start <program>  The start program.                             
-  -C, --cert <path>      The path to the certificate file.              
-  -K, --key <path>       The path to the key file.                      
-  -h, --help             Displays this help.                            
-  -v, --version          Displays version information.                  
+  -p, --port <port>         The web term server port.                      
+  -d, --daemon              Start web term as background process.          
+  -c, --cwd <path>          The path to the web terminal current working   
+                            directory.                                     
+  -H, --host <0.0.0.0>      The host to listen to.                         
+  -o, --open                If provided, the web term will be automatically
+                            opened in the default browser.                 
+  -b, --shell <program>     The shell program. By default `bash`.          
+  -s, --start <program>     The start program.                             
+  -C, --cert <path>         The path to the certificate file.              
+  -K, --key <path>          The path to the key file.                      
+  -P, --pty-options <json>  Additional options to pass to the pty library. 
+  -h, --help                Displays this help.                            
+  -v, --version             Displays version information.                  
 
 Examples:
   web-term # Default behavior
@@ -45,7 +48,7 @@ Examples:
 
 Documentation can be found at https://github.com/IonicaBizau/web-term
 ```
-
+    
 ## Screenshots
 ### VIM
 ![](http://i.imgur.com/49FTpfI.png)
@@ -53,25 +56,25 @@ Documentation can be found at https://github.com/IonicaBizau/web-term
 ### Alsamixer
 ![](http://i.imgur.com/rJbtLdi.jpg)
 
-## Documentation
-
+## :memo: Documentation
+        
 For full API reference, see the [DOCUMENTATION.md][docs] file.
-
-## How to contribute
+            
+## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
-## Thanks
+## :cake: Thanks
 This project is highly based on [`tty.js`](https://github.com/chjj/tty.js) created by [@chjj](https://github.com/chjj). Thanks a lot for this awesome stuff!
 
-## Where is this library used?
+## :dizzy: Where is this library used?
 If you are using this library in one of your projects, add it in this list. :sparkles:
 
- - [`magnesium`](https://github.com/IonicaBizau/magnesium#readme)
+ - [`magnesium`](https://github.com/IonicaBizau/magnesium#readme)—A terminal emulator based on Electron.
 
-## License
-
+## :scroll: License
+    
 [MIT][license] © [Ionică Bizău][website]
-
+    
 [paypal-donations]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RVXDDLKKLQRJW
 [donate-now]: http://i.imgur.com/6cMbHOC.png
 

--- a/bin/web-term
+++ b/bin/web-term
@@ -25,6 +25,7 @@ var portOption = new Clp.Option(["p", "port"], "The web term server port.", "por
   , startOption = new Clp.Option(["s", "start"], "The start program.", "program")
   , certOption = new Clp.Option(["C", "cert"], "The path to the certificate file.", "path")
   , keyOption = new Clp.Option(["K", "key"], "The path to the key file.", "path")
+  , ptyOptionsOption = new Clp.Option(["P", "pty-options"], "Additional options to pass to the pty library.", "json")
   , parser = new Clp({
         name: "Web Term"
       , version: Package.version
@@ -41,7 +42,7 @@ var portOption = new Clp.Option(["p", "port"], "The web term server port.", "por
           , "web-term -C path/to/cert.pem -K path/to/key.pem # https support"
         ]
       , docs_url: Package.homepage
-    }, [portOption, daemonOption, cwdOption, hostOption, openOption, shellOption, startOption, certOption, keyOption])
+    }, [portOption, daemonOption, cwdOption, hostOption, openOption, shellOption, startOption, certOption, keyOption, ptyOptionsOption])
   ;
 
 
@@ -129,6 +130,14 @@ app.page.add("/api/settings/get", function (lien) {
     });
 });
 
+if (ptyOptionsOption.is_provided) {
+    try {
+        ptyOptionsOption.value = JSON.parse(ptyOptionsOption.value);
+    } catch (e) {
+        return Logger.log(new Error("Failed to parse the pty options. Make sure you pass valid data."));
+    }
+}
+
 // Handle connections
 app.io.sockets.on("connection", function(socket) {
     var req = socket.handshake;
@@ -146,6 +155,13 @@ app.io.sockets.on("connection", function(socket) {
               , socket: socket
               , start: startOption.value || settings.general.custom_command || undefined
               , shell: shellOption.value || settings.general.shell
+           // , ptyOptions: {
+           //     env: {
+           //        WEB_TERM_USER: "my-web-term-user",
+           //        WEB_TERM_HOST: "my-web-term-host",
+           //     }
+           //  }
+              , ptyOptions: ptyOptionsOption.value
             });
             callback();
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,8 @@ WebTerm.config_file_path = abs("~/.web-term.json");
  *  - `cwd` (String): The current working directory (default: the home directory).
  *  - `shell` (String): The shell to start (by default the shell).
  *  - `start` (String): The start program.
+ *  - `ptyOptions` (Object): Custom options for the pty.js fork call
+ *  - `inheritEnv` (Boolean): If `false`, it will prevent web-term to take the environment variables from the main process.
  *
  * @return {Terminal} The terminal instance.
  */
@@ -47,12 +49,16 @@ WebTerm.prototype.create = function (options, callback) {
     options.shell = deffy(options.shell, process.env.SHELL);
     WebTerm.sockets.push(options.socket);
 
+    if (options.ptyOptions && options.ptyOptions.env && options.inheritEnv !== false) {
+        options.ptyOptions.env = ul.merge(options.ptyOptions.env, process.env);
+    }
+
     // Create the terminal
-    self.terminal = pty.fork(options.shell, [], {
+    self.terminal = pty.fork(options.shell, [], ul.merge({
         cols: options.cols
       , rows: options.rows
       , cwd: options.cwd || ul.home()
-    });
+    }, options.ptyOptions));
 
     // Terminal -> Socket
     self.terminal.on("data", function(data) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-term",
-  "version": "4.9.1",
+  "version": "4.10.0",
   "description": "A full screen terminal in your browser.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
Especially when we need have to use custom environment variables.

Example:

``` sh
./bin/web-term --pty-options '{ "env": { "MY_ENV_VARIABLE": "..." } }'
```

When using it as library:

``` js
let myTerm = new WebTerm({
   cols: 80
 , rows: 60
 , socket: ...
 , ptyOptions: {
      env: {
          WEB_TERM_USER: "my-web-term-user",
          WEB_TERM_HOST: "my-web-term-host",
       }
   }
});
```
